### PR TITLE
Do some spring cleaning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,27 +21,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -73,7 +58,6 @@ name = "mvn-autoenforce"
 version = "0.1.6-alpha.0"
 dependencies = [
  "atty",
- "itertools",
  "regex",
  "version-compare",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ lto = "fat"
 [dependencies]
 regex = "1"
 version-compare = "0.0.11"
-itertools = "0.10.0"
 atty = "0.2"

--- a/src/dependency/mod.rs
+++ b/src/dependency/mod.rs
@@ -1,0 +1,72 @@
+mod version;
+
+use core::cmp::{Eq, Ord, Ordering};
+use core::fmt::{Display, Error, Formatter};
+use core::result::Result;
+
+use crate::dependency::version::create_version;
+use regex::Regex;
+use version_compare::Version;
+
+#[derive(Debug, PartialEq, PartialOrd)]
+pub struct Dependency<'a> {
+    pub group_id: &'a str,
+    pub artifact_id: &'a str,
+    pub version: Version<'a>,
+}
+
+impl<'a> Eq for Dependency<'a> {}
+
+impl<'a> Ord for Dependency<'a> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.group_id
+            .cmp(other.group_id)
+            .then_with(|| self.artifact_id.cmp(other.artifact_id))
+            .then_with(|| self.version.partial_cmp(&other.version).unwrap())
+    }
+}
+
+impl<'a> Display for Dependency<'a> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        write!(
+            f,
+            r#"
+    <dependency>
+        <groupId>{}</groupId>
+        <artifactId>{}</artifactId>
+        <version>{}</version>
+    </dependency>"#,
+            self.group_id,
+            self.artifact_id,
+            self.version.as_str()
+        )
+    }
+}
+
+pub fn max_by_dep<'a>(dependency: Dependency<'a>, output: &'a str) -> Option<Dependency<'a>> {
+    let version_regex = Regex::new(
+        format!(
+            "\\S{}:{}:(\\S+)",
+            dependency.group_id, dependency.artifact_id
+        )
+        .as_ref(),
+    )
+    .unwrap();
+
+    version_regex
+        .captures_iter(output)
+        .map(|v| Dependency {
+            version: create_version(v.get(1).unwrap().as_str()),
+            ..dependency
+        })
+        .max_by(Ord::cmp)
+}
+
+pub fn parse_dependency(dependency: &str) -> Dependency {
+    let coordinates: Vec<&str> = dependency.split(':').collect();
+    Dependency {
+        group_id: coordinates[0],
+        artifact_id: coordinates[1],
+        version: create_version(coordinates[2]),
+    }
+}

--- a/src/dependency/version.rs
+++ b/src/dependency/version.rs
@@ -1,0 +1,35 @@
+use core::result::Result::{Err, Ok};
+use version_compare::version::Version;
+use version_compare::version_part::VersionPart;
+
+pub fn create_version(version_string: &str) -> Version {
+    let initial_version = Version::from(version_string)
+        .unwrap_or_else(|| panic!("Unparseable version '{}'", version_string));
+    Version::from_parts(
+        version_string,
+        initial_version
+            .parts()
+            .iter()
+            .map(explode_part)
+            .flatten()
+            .collect(),
+    )
+}
+
+fn explode_part<'a>(version_part: &VersionPart<'a>) -> Vec<VersionPart<'a>> {
+    match version_part {
+        VersionPart::Number(val) => {
+            vec![VersionPart::Number(*val)]
+        }
+        VersionPart::Text(val) => {
+            let split: Vec<&str> = val.split('-').collect();
+            split
+                .iter()
+                .map(|part| match part.parse::<i32>() {
+                    Ok(number) => VersionPart::Number(number),
+                    Err(_) => VersionPart::Text(part),
+                })
+                .collect()
+        }
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,0 +1,27 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+use std::cmp::Ordering;
+
+type VecIntoIter<T> = alloc::vec::IntoIter<T>;
+
+pub trait SortedByExt: Iterator {
+    fn sorted_by<F>(self, cmp: F) -> VecIntoIter<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    {
+        /*
+        This whole thing is stolen from itertools, with a slight modification due to clippy lint.
+        In itertools Vec::from_iter() is used but we get the aforementioned clippy complaint
+        and it recommends a .collect().
+        But with collect rustc gets confused and requires type annotations on the var or on
+        the collect() call.
+        */
+        let mut v = self.collect::<Vec<Self::Item>>();
+        v.sort_by(cmp);
+        v.into_iter()
+    }
+}
+
+impl<I: Iterator> SortedByExt for I {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,19 +28,19 @@ fn parse(input: &str) -> Vec<Dependency> {
         .collect()
 }
 
-fn main() -> io::Result<()> {
+fn main() {
     if env::args().any(|arg| arg.eq(&String::from("-v")) || arg.eq(&String::from("--version"))) {
         const NAME: &str = env!("CARGO_PKG_NAME");
         const VERSION: &str = env!("CARGO_PKG_VERSION");
         println!("{} {}", NAME, VERSION);
-        return Ok(());
+        return;
     }
 
     if atty::is(Stream::Stdin) {
         eprintln!(
             "Stdin is a terminal, you should pipe the output of mvn validate to this program"
         );
-        return Ok(());
+        return;
     }
 
     let stdin = io::stdin();
@@ -53,7 +53,6 @@ fn main() -> io::Result<()> {
             .iter()
             .for_each(|dep| println!("{}", dep)),
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,128 +3,17 @@ extern crate itertools;
 extern crate regex;
 extern crate version_compare;
 
-use std::cmp::Ordering;
 use std::env;
-use std::fmt::Display;
-use std::fmt::Error;
-use std::fmt::Formatter;
 use std::io;
 use std::io::Read;
 
 use atty::Stream;
 use itertools::Itertools;
 use regex::Regex;
-use version_compare::Version;
-use version_compare::VersionPart;
 
-#[derive(Debug)]
-struct Dependency<'a> {
-    group_id: &'a str,
-    artifact_id: &'a str,
-    version: Version<'a>,
-}
+use crate::dependency::{max_by_dep, parse_dependency, Dependency};
 
-impl<'a> PartialEq for Dependency<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        self.group_id == other.group_id
-            && self.artifact_id == other.artifact_id
-            && self.version == other.version
-    }
-}
-
-impl<'a> Eq for Dependency<'a> {}
-
-impl<'a> PartialOrd for Dependency<'a> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<'a> Ord for Dependency<'a> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.group_id
-            .cmp(other.group_id)
-            .then_with(|| self.artifact_id.cmp(other.artifact_id))
-            .then_with(|| self.version.partial_cmp(&other.version).unwrap())
-    }
-}
-
-impl<'a> Display for Dependency<'a> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(
-            f,
-            r#"
-    <dependency>
-        <groupId>{}</groupId>
-        <artifactId>{}</artifactId>
-        <version>{}</version>
-    </dependency>"#,
-            self.group_id,
-            self.artifact_id,
-            self.version.as_str()
-        )
-    }
-}
-
-fn max_by_dep<'a>(dependency: Dependency<'a>, output: &'a str) -> Option<Dependency<'a>> {
-    let version_regex = Regex::new(
-        format!(
-            "\\S{}:{}:(\\S+)",
-            dependency.group_id, dependency.artifact_id
-        )
-        .as_ref(),
-    )
-    .unwrap();
-
-    version_regex
-        .captures_iter(output)
-        .map(|v| Dependency {
-            version: create_version(v.get(1).unwrap().as_str()),
-            ..dependency
-        })
-        .max_by(Ord::cmp)
-}
-
-fn parse_dependency(dependency: &str) -> Dependency {
-    let coordinates: Vec<&str> = dependency.split(':').collect();
-    Dependency {
-        group_id: coordinates[0],
-        artifact_id: coordinates[1],
-        version: create_version(coordinates[2]),
-    }
-}
-
-fn create_version(version_string: &str) -> Version {
-    let initial_version = Version::from(version_string)
-        .unwrap_or_else(|| panic!("Unparseable version '{}'", version_string));
-    Version::from_parts(
-        version_string,
-        initial_version
-            .parts()
-            .iter()
-            .map(explode_part)
-            .flatten()
-            .collect(),
-    )
-}
-
-fn explode_part<'a>(version_part: &VersionPart<'a>) -> Vec<VersionPart<'a>> {
-    match version_part {
-        VersionPart::Number(val) => {
-            vec![VersionPart::Number(*val)]
-        }
-        VersionPart::Text(val) => {
-            let split: Vec<&str> = val.split('-').collect();
-            split
-                .iter()
-                .map(|part| match part.parse::<i32>() {
-                    Ok(number) => VersionPart::Number(number),
-                    Err(_) => VersionPart::Text(part),
-                })
-                .collect()
-        }
-    }
-}
+mod dependency;
 
 fn parse(input: &str) -> Vec<Dependency> {
     let upper_bounds =
@@ -170,6 +59,7 @@ fn main() -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use version_compare::Version;
 
     #[test]
     fn parse_should_return_vec_of_deps_on_validate_failed_input() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 extern crate atty;
-extern crate itertools;
 extern crate regex;
 extern crate version_compare;
 
@@ -8,12 +7,13 @@ use std::io;
 use std::io::Read;
 
 use atty::Stream;
-use itertools::Itertools;
 use regex::Regex;
 
 use crate::dependency::{max_by_dep, parse_dependency, Dependency};
+use crate::iter::SortedByExt;
 
 mod dependency;
+mod iter;
 
 fn parse(input: &str) -> Vec<Dependency> {
     let upper_bounds =
@@ -58,8 +58,9 @@ fn main() -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use version_compare::Version;
+
+    use super::*;
 
     #[test]
     fn parse_should_return_vec_of_deps_on_validate_failed_input() {


### PR DESCRIPTION
Move dependency struct and methods into it's own module and auto derive some things.
Move version things into module.
Remove itertools dependency and provide our own implementation