### PR TITLE
Prepare for 1.0.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,8 @@ jobs:
       - name: "Compile and test"
         uses: icepuma/rust-action@master
         with:
-          args: cargo fmt -- --check && cargo clippy -- -Dwarnings && cargo test
+          entrypoint: /bin/bash
+          args: ./build-and-test.sh
       - name: "UI Test"
         uses: icepuma/rust-action@master
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,18 +24,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "memchr"
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mvn-autoenforce"
 version = "0.1.11"
-authors = ["Olle Lundberg <geek@nerd.sh>"]
+authors = ["Olle Lundberg <hey@olle.lu>"]
 description = "Parses maven enforcer output and gives you the topmost version of dependencies"
 repository = "https://github.com/lndbrg/mvn-autoenforce.git"
 homepage = "https://github.com/lndbrg/mvn-autoenforce"
 readme = "README.md"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # mvn-autoenforce
 
 ## Motivation
-Managing dependencies is hard and transitive dependencies might leak into your project which might have unforeseen
-side effects during runtime (some would call them bugs, I call it adding some spiciness to your code). Most people 
-do want to avoid the added spiciness of the unknown side effects and for maven based java projects a good way to do that
-is using the `RequireUpperBoundDeps` rules of the `maven-enforcer-plugin` plugin. This plugin usually runs during the
-`validate` phase of your build lifecycle and if it happens to stumble upon conflicting dependency versions it gives you
-a wall of text that mostly just induces eye strain and takes a while to parse for the human eye and brain.
+Managing dependencies are hard, managing dependencies with multiple versions are even harder and transitive dependencies
+might even leak into your project which can lead to unforeseen side effects during runtime (some would call these side
+effects bugs 🪳, I call them code spice 🌶).
+
+Most people prefer their code to be without added spice and behave the way that they intended and avoid these unknown
+side effects, for maven based projects a good way to do that is using the `RequireUpperBoundDeps` rules of the
+`maven-enforcer-plugin`. This plugin usually runs during the `validate` phase of your build lifecycle and if it happens
+to stumble upon conflicting dependency versions it gives you a wall of text that mostly just induces eye strain.
+It also takes a while to parse this wall of for the human eye and brain, alas the meat machines that we are where
+optimized to look at prettier things.
 
 This CLI tool exists to help you parse that wall of text and outputs the topmost dependency version of the problematic
 dependency in your pom. The output is in the very new and fancy markup language called XML

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -xeuo pipefail
+cargo fmt -- --check;
+cargo clippy -- -Dwarnings;
+cargo test;

--- a/expected-cli.out
+++ b/expected-cli.out
@@ -1,3 +1,4 @@
+Failed to parse version for coordinates 'com.h2database:h2': Failed to parse version from: 'BROKEN'
 
     <dependency>
         <groupId>com.h2database</groupId>

--- a/src/dependency/errors.rs
+++ b/src/dependency/errors.rs
@@ -1,0 +1,57 @@
+use std::error::Error;
+use std::fmt;
+use std::fmt::Display;
+
+#[derive(Debug, PartialEq)]
+pub struct UnparseableVersionError {
+    version_string: String,
+}
+
+impl Error for UnparseableVersionError {}
+
+impl From<&str> for UnparseableVersionError {
+    fn from(version_string: &str) -> Self {
+        Self {
+            version_string: version_string.to_string(),
+        }
+    }
+}
+
+impl Display for UnparseableVersionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Failed to parse version from: '{}'",
+            &self.version_string
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DependencyParseError {
+    CoordinateError(String),
+    VersionError(String, String, UnparseableVersionError),
+}
+
+impl Error for DependencyParseError {}
+
+impl Display for DependencyParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DependencyParseError::CoordinateError(coords) => {
+                write!(
+                    f,
+                    "Failed to parse dependency coordinates from: '{}'",
+                    coords
+                )
+            }
+            DependencyParseError::VersionError(group_id, artifact_id, version_error) => {
+                write!(
+                    f,
+                    "Failed to parse version for coordinates '{}:{}': {}",
+                    group_id, artifact_id, version_error
+                )
+            }
+        }
+    }
+}

--- a/src/dependency/version.rs
+++ b/src/dependency/version.rs
@@ -1,34 +1,73 @@
-use core::result::Result::{Err, Ok};
-use version_compare::version::Version;
+use core::result::Result::Ok;
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::ops::Deref;
+
+use version_compare::version::Version as InnerVersion;
 use version_compare::version_part::VersionPart;
 
-pub fn create_version(version_string: &str) -> Version {
-    let initial_version = Version::from(version_string)
-        .unwrap_or_else(|| panic!("Unparseable version '{}'", version_string));
-    Version::from_parts(
-        version_string,
-        initial_version
-            .parts()
-            .iter()
-            .flat_map(explode_part)
-            .collect(),
-    )
+use crate::dependency::errors::UnparseableVersionError;
+
+/*
+This is a bit ugly, but we create a wrapper struct for the foreign `Version` struct (called
+`InnerVersion`) in order to be able to implement the `TryFrom` trait. We later implement `Deref`
+for `Version` in order to forward calls to `InnerVersion`.
+
+It's extremely unlikely to actually get an error from the `Version::try_from` as we have very well
+defined regexes as guards. These guards should make sure we never even call try_from unless we have
+output from maven that matches a coordinate string. If someone for some reason has managed to create
+an alphabetical version and gotten it uploaded somewhere we will fail to parse it.
+*/
+#[derive(Debug, PartialEq, PartialOrd)]
+pub struct Version<'a> {
+    inner: InnerVersion<'a>,
+}
+
+impl<'a> Eq for Version<'a> {}
+
+impl<'a> Ord for Version<'a> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.partial_cmp(&other.inner).unwrap()
+    }
+}
+
+impl<'a> Deref for Version<'a> {
+    type Target = InnerVersion<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a> TryFrom<&'a str> for Version<'a> {
+    type Error = UnparseableVersionError;
+
+    fn try_from(version_string: &'a str) -> Result<Self, Self::Error> {
+        let initial_version = InnerVersion::from(version_string)
+            .ok_or_else(|| UnparseableVersionError::from(version_string))?;
+
+        Ok(Version {
+            inner: InnerVersion::from_parts(
+                version_string,
+                initial_version
+                    .parts()
+                    .iter()
+                    .flat_map(explode_part)
+                    .collect(),
+            ),
+        })
+    }
 }
 
 fn explode_part<'a>(version_part: &VersionPart<'a>) -> Vec<VersionPart<'a>> {
     match version_part {
-        VersionPart::Number(val) => {
-            vec![VersionPart::Number(*val)]
-        }
-        VersionPart::Text(val) => {
-            let split: Vec<&str> = val.split('-').collect();
-            split
-                .iter()
-                .map(|part| match part.parse::<i32>() {
-                    Ok(number) => VersionPart::Number(number),
-                    Err(_) => VersionPart::Text(part),
-                })
-                .collect()
-        }
+        VersionPart::Number(val) => vec![VersionPart::Number(*val)],
+        VersionPart::Text(val) => val
+            .split('-')
+            .map(|part| match part.parse::<i32>() {
+                Ok(number) => VersionPart::Number(number),
+                Err(_) => VersionPart::Text(part),
+            })
+            .collect(),
     }
 }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,12 +1,10 @@
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::vec::{IntoIter, Vec};
 use std::cmp::Ordering;
 
-type VecIntoIter<T> = alloc::vec::IntoIter<T>;
-
 pub trait SortedByExt: Iterator {
-    fn sorted_by<F>(self, cmp: F) -> VecIntoIter<Self::Item>
+    fn sorted_by<F>(self, cmp: F) -> IntoIter<Self::Item>
     where
         Self: Sized,
         F: FnMut(&Self::Item, &Self::Item) -> Ordering,
@@ -24,4 +22,4 @@ pub trait SortedByExt: Iterator {
     }
 }
 
-impl<I: Iterator> SortedByExt for I {}
+impl<T: ?Sized> SortedByExt for T where T: Iterator {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate atty;
 extern crate regex;
 
+use std::convert::TryFrom;
 use std::env;
 use std::io;
 use std::io::Read;
@@ -8,23 +9,34 @@ use std::io::Read;
 use atty::Stream;
 use regex::Regex;
 
+use crate::dependency::errors::DependencyParseError;
 use crate::dependency::{max_by_dep, Dependency};
 use crate::iter::SortedByExt;
 
 mod dependency;
 mod iter;
 
-fn parse(input: &str) -> Vec<Dependency> {
+fn parse(input: &str) -> Result<Vec<Dependency>, DependencyParseError> {
     let upper_bounds =
-        Regex::new("Require upper bound dependencies error for (.*) paths to dependency are:")
+        Regex::new("Require upper bound dependencies error for (\\S+) paths to dependency are:")
             .unwrap();
 
-    upper_bounds
+    let dependencies = upper_bounds
         .captures_iter(input)
-        .map(|cap| Dependency::from(cap.get(1).unwrap().as_str()))
-        .flat_map(|dep| max_by_dep(dep, input))
+        .flat_map(|cap| cap.iter().nth(1).flatten())
+        .map(|m| m.as_str())
+        .map(Dependency::try_from)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let dependencies_by_max = dependencies
+        .into_iter()
+        .map(|dep| max_by_dep(dep, input))
+        .collect::<Result<Vec<Dependency>, _>>()?;
+
+    Ok(dependencies_by_max
+        .into_iter()
         .sorted_by(Ord::cmp)
-        .collect()
+        .collect())
 }
 
 fn main() {
@@ -42,15 +54,14 @@ fn main() {
         return;
     }
 
-    let stdin = io::stdin();
-    let mut handle = stdin.lock();
     let mut buffer = String::new();
 
-    match handle.read_to_string(&mut buffer) {
-        Err(err) => panic!("Failed to read from stdin {}", err),
-        Ok(_) => parse(buffer.as_str())
-            .iter()
-            .for_each(|dep| println!("{}", dep)),
+    match io::stdin().lock().read_to_string(&mut buffer) {
+        Err(err) => eprintln!("Failed to read from stdin {}", err),
+        Ok(_) => match parse(buffer.as_str()) {
+            Err(e) => eprintln!("{}", e),
+            Ok(deps) => deps.iter().for_each(|dep| println!("{}", dep)),
+        },
     }
 }
 
@@ -61,33 +72,36 @@ mod tests {
     #[test]
     fn parse_should_return_vec_of_deps_on_validate_failed_input() {
         let failed = include_str!("../test/fixtures/fail-one-regular.out");
-        let deps = parse(failed);
+        let deps = parse(failed).unwrap();
         assert_eq!(
             deps,
-            vec![Dependency::from(
-                "org.jenkins-ci.plugins.workflow:workflow-api:2.32"
-            )]
+            vec![
+                Dependency::try_from("org.jenkins-ci.plugins.workflow:workflow-api:2.32").unwrap()
+            ]
         )
     }
 
     #[test]
     fn parse_should_return_vec_of_deps_on_validate_failed_with_managed_input() {
         let failed = include_str!("../test/fixtures/fail-managed.out");
-        let deps = parse(failed);
-        assert_eq!(deps, vec![Dependency::from("com.h2database:h2:1.4.190"),])
+        let deps = parse(failed).unwrap();
+        assert_eq!(
+            deps,
+            vec![Dependency::try_from("com.h2database:h2:1.4.190").unwrap()]
+        )
     }
 
     #[test]
     fn parse_should_return_vec_of_deps_on_validate_failed_with_multiple_bound_concflicts_input() {
         let failed = include_str!("../test/fixtures/fail-multiple.out");
-        let deps = parse(failed);
+        let deps = parse(failed).unwrap();
         assert_eq!(
             deps,
             vec![
-                Dependency::from("org.codehaus.groovy:groovy-all:2.4.12"),
-                Dependency::from("org.slf4j:jcl-over-slf4j:1.7.26"),
-                Dependency::from("org.slf4j:log4j-over-slf4j:1.7.26"),
-                Dependency::from("org.slf4j:slf4j-jdk14:1.7.26")
+                Dependency::try_from("org.codehaus.groovy:groovy-all:2.4.12").unwrap(),
+                Dependency::try_from("org.slf4j:jcl-over-slf4j:1.7.26").unwrap(),
+                Dependency::try_from("org.slf4j:log4j-over-slf4j:1.7.26").unwrap(),
+                Dependency::try_from("org.slf4j:slf4j-jdk14:1.7.26").unwrap(),
             ]
         )
     }
@@ -95,7 +109,7 @@ mod tests {
     #[test]
     fn parse_should_return_empty_vec_on_validate_successful_input() {
         let success = include_str!("../test/fixtures/success.out");
-        let deps = parse(success);
+        let deps = parse(success).unwrap();
         assert_eq!(deps, vec![])
     }
 }

--- a/test/fixtures/fail-broken-version.out
+++ b/test/fixtures/fail-broken-version.out
@@ -1,0 +1,6 @@
+[INFO] --- maven-enforcer-plugin:1.4:enforce (enforce-maven) @ my-service ---
+[WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
+Failed while enforcing RequireUpperBoundDeps. The error(s) are [
+Require upper bound dependencies error for com.h2database:h2:1.3.168 paths to dependency are:
++-com.example.services:my-service:1.0.0-SNAPSHOT
+  +-com.h2database:h2:BROKEN

--- a/ui-test.sh
+++ b/ui-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeuo pipefail
 RESULT=$(for file in test/fixtures/*; do
-	cat $file | cargo run --release -q;
+	cargo run --release -q 2>&1 -- <"${file}";
 done)
 
 diff -u ./expected-cli.out <(echo "${RESULT}")


### PR DESCRIPTION
This is a major rewrite providing better error handling (some details still needs to be worked out) no more `panic!` (either as exit or as a potential failure), and better documentation in code. There still some small work to be done in order to present the errors better to the end user. But when that is done i expect to release a 1.0.0 and don't foresee any other changes to the binary (of course there might be some bugs popping up, but those are unforeseen), so when that is released i expect the project to be done.